### PR TITLE
[BUGFIX] Extract database modification hook

### DIFF
--- a/Classes/Hook/DatabaseConnectionHook.php
+++ b/Classes/Hook/DatabaseConnectionHook.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Psychomieze\AdminpanelExtended\Hook;
+
+use Doctrine\DBAL\Logging\DebugStack;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class DatabaseConnectionHook
+ */
+final class DatabaseConnectionHook
+{
+    /**
+     * Add a logger to the default connection
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function modifyConnection(): void
+    {
+        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+        $connection = $connectionPool->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
+        $connection->getConfiguration()->setSQLLogger(new DebugStack());
+    }
+}

--- a/Classes/Modules/DoctrineDebugModule.php
+++ b/Classes/Modules/DoctrineDebugModule.php
@@ -3,26 +3,17 @@ declare(strict_types=1);
 
 namespace Psychomieze\AdminpanelExtended\Modules;
 
-use Doctrine\DBAL\Logging\DebugStack;
 use TYPO3\CMS\Adminpanel\Modules\AbstractModule;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 
+/**
+ * Class DoctrineDebugModule
+ */
 class DoctrineDebugModule extends AbstractModule
 {
     private $queryCount = 0;
-
-    /**
-     * @throws \InvalidArgumentException
-     * @throws \Doctrine\DBAL\DBALException
-     */
-    public function modifyConnection(): void
-    {
-        $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
-        $connection = $connectionPool->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME);
-        $connection->getConfiguration()->setSQLLogger(new DebugStack());
-    }
 
     /**
      * @return string Returns content of admin panel

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,8 +1,8 @@
 <?php
 defined('TYPO3_MODE') or die('Access denied.');
 if (TYPO3_MODE === 'FE') {
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['connectToDB'][] = \Psychomieze\AdminpanelExtended\Modules\DoctrineDebugModule::class .
-                                                                                             '->modifyConnection';
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['connectToDB'][] = \Psychomieze\AdminpanelExtended\Hook\DatabaseConnectionHook::class .
+        '->modifyConnection';
 
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['adminpanel']['modules']['admext_doctrinedebug'] = [
         'module' => \Psychomieze\AdminpanelExtended\Modules\DoctrineDebugModule::class,


### PR DESCRIPTION
Tough the hook was part of the module class, it caused an exception because `$GLOBALS['BE_USER']` was not available. 

The exception was thrown because `TYPO3\CMS\Adminpanel\Modules\AbstractModule` uses `$GLOBALS['BE_USER']` in its `__constructor`. The initialization of `$GLOBALS['BE_USER']` has been changed and moved after the initialization of `$GLOBALS['TSFE']`.

This patch extracts the hook so the module does not need to be initialized that early.