### PR TITLE
[TASK] Add a lightweight development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-composer.lock
-.Build/
+/.Build/
+/.idea/
+/composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 - >
   echo;
   echo "PHP lint";
-  find . -name \*.php ! -path "./.build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
+  find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+# .travis.yml
+sudo: false
+language: php
+
+php:
+- 7.2
+
+env:
+- TYPO3_VERSION=^9
+
+addons:
+  apt:
+    packages:
+    - parallel
+
+install:
+- composer require typo3/minimal:${TYPO3_VERSION}
+- git checkout composer.json
+- export TYPO3_PATH_WEB="$PWD/.Build/web"
+
+script:
+- >
+  echo;
+  echo "Unit tests";
+  .Build/vendor/phpunit/phpunit/phpunit -c Build/phpunit.xml
+
+- >
+  echo;
+  echo "PHP lint";
+  find . -name \*.php ! -path "./.build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
+
+cache:
+  directories:
+  - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,15 @@ script:
 - >
   echo;
   echo "Unit tests";
-  .Build/vendor/phpunit/phpunit/phpunit -c Build/phpunit.xml
+  .Build/vendor/phpunit/phpunit/phpunit -c Build/phpunit.xml --coverage-clover .Build/coverage.xml
 
 - >
   echo;
   echo "PHP lint";
   find . -name \*.php ! -path "./.Build/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
+
+after_script:
+- .Build/vendor/bin/codacycoverage clover .Build/coverage.xml
 
 cache:
   directories:

--- a/Build/phpunit.xml
+++ b/Build/phpunit.xml
@@ -1,0 +1,26 @@
+<phpunit
+	backupGlobals="true"
+	bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertWarningsToExceptions="true"
+	forceCoversAnnotation="false"
+	processIsolation="false"
+	stopOnError="false"
+	stopOnFailure="false"
+	stopOnIncomplete="false"
+	stopOnSkipped="false"
+	verbose="false"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+>
+	<testsuites>
+		<testsuite name="UnitTests">
+			<directory>../Tests/Unit</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">../Classes/</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/Classes/Composer/ScriptHelper.php
+++ b/Classes/Composer/ScriptHelper.php
@@ -18,7 +18,7 @@ final class ScriptHelper
         }
 
         if (!is_link(self::LINK)) {
-            symlink('../../../../.', self::LINK);
+            symlink(dirname(__DIR__, 2) . '/', self::LINK);
         }
     }
 }

--- a/Classes/Composer/ScriptHelper.php
+++ b/Classes/Composer/ScriptHelper.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Psychomieze\AdminpanelExtended\Composer;
+
+final class ScriptHelper
+{
+    private const EXTENSION_DIRECTORY = './.Build/web/typo3conf/ext';
+
+    private const LINK = self::EXTENSION_DIRECTORY . '/adminpanel_extended';
+
+    public static function ensureExtensionStructure(): void
+    {
+        if (!is_dir(self::EXTENSION_DIRECTORY) && !mkdir(self::EXTENSION_DIRECTORY)) {
+            throw new \RuntimeException(sprintf('Directory "%s" could not be created', self::EXTENSION_DIRECTORY));
+        }
+
+        if (!is_link(self::LINK)) {
+            symlink('../../../../.', self::LINK);
+        }
+    }
+}

--- a/Classes/Composer/ScriptHelper.php
+++ b/Classes/Composer/ScriptHelper.php
@@ -5,13 +5,15 @@ namespace Psychomieze\AdminpanelExtended\Composer;
 
 final class ScriptHelper
 {
-    private const EXTENSION_DIRECTORY = './.Build/web/typo3conf/ext';
+    private const EXTENSION_DIRECTORY = __DIR__ . '/../../.Build/web/typo3conf/ext';
 
     private const LINK = self::EXTENSION_DIRECTORY . '/adminpanel_extended';
 
     public static function ensureExtensionStructure(): void
     {
-        if (!is_dir(self::EXTENSION_DIRECTORY) && !mkdir(self::EXTENSION_DIRECTORY)) {
+        if (!is_dir(self::EXTENSION_DIRECTORY) &&
+            !mkdir($concurrentDirectory = self::EXTENSION_DIRECTORY, 0775, true) &&
+            !is_dir($concurrentDirectory)) {
             throw new \RuntimeException(sprintf('Directory "%s" could not be created', self::EXTENSION_DIRECTORY));
         }
 

--- a/Tests/Unit/Modules/HooksAndSignals/LoggedArrayTest.php
+++ b/Tests/Unit/Modules/HooksAndSignals/LoggedArrayTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Psychomieze\AdminpanelExtended\Tests\Unit\Modules\HooksAndSignals;
+
+use PHPUnit\Framework\TestCase;
+use Psychomieze\AdminpanelExtended\Modules\HooksAndSignals\LoggedArray;
+
+class LoggedArrayTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function offsetExistsReturnsFalse(): void
+    {
+        $loggedArray = new LoggedArray([]);
+        $result = $loggedArray->offsetExists('non-existing');
+        self::assertFalse($result);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,37 @@
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",
+    "typo3/cms-install": "9.5.*@dev",
+    "typo3/cms-extensionmanager": "9.5.*@dev",
+    "typo3/cms-recordlist": "9.5.*@dev",
     "slevomat/coding-standard": "^4.8"
   },
   "replace": {
-    "introduction": "*"
+    "adminpanel_extended": "self.version"
   },
   "autoload": {
     "psr-4": {
       "Psychomieze\\AdminpanelExtended\\": "Classes/"
     }
+  },
+  "config": {
+    "vendor-dir": ".Build/vendor",
+    "bin-dir": ".Build/bin"
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "adminpanel_extended",
+      "cms-package-dir": "{$vendor-dir}/typo3/cms",
+      "app-dir": ".Build",
+      "web-dir": ".Build/web"
+    }
+  },
+  "scripts": {
+    "create-extension-directory": "mkdir -p .Build/web/typo3conf/ext",
+    "link-package": "ln -snvf ../../../../. .Build/web/typo3conf/ext/adminpanel_extended",
+    "post-update-cmd": [
+      "@create-extension-directory",
+      "@link-package"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,11 @@
     }
   },
   "scripts": {
-    "create-extension-directory": "mkdir -p .Build/web/typo3conf/ext",
-    "link-package": "ln -snvf ../../../../. .Build/web/typo3conf/ext/adminpanel_extended",
     "post-update-cmd": [
-      "@create-extension-directory",
-      "@link-package"
+      "@ensure-extension-structure"
+    ],
+    "ensure-extension-structure": [
+      "Psychomieze\\AdminpanelExtended\\Composer\\ScriptHelper::ensureExtensionStructure"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "homepage": "https://typo3.org",
   "require": {
     "typo3/cms-adminpanel": "9.5.*@dev",
-    "typo3/testing-framework": "^4.9"
+    "typo3/testing-framework": "^4.9",
+    "codacy/coverage": "^1.4"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
   "description": "TYPO3 AdminPanel Extended",
   "homepage": "https://typo3.org",
   "require": {
-    "typo3/cms-adminpanel": "9.5.*@dev"
+    "typo3/cms-adminpanel": "9.5.*@dev",
+    "typo3/testing-framework": "^4.9"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",
@@ -40,6 +41,12 @@
     ],
     "ensure-extension-structure": [
       "Psychomieze\\AdminpanelExtended\\Composer\\ScriptHelper::ensureExtensionStructure"
+    ],
+    "test:php:unit": [
+      "@php .build/vendor/phpunit/phpunit/phpunit -c Build/phpunit.xml"
+    ],
+    "test": [
+      "@test:php:unit"
     ]
   }
 }


### PR DESCRIPTION
This patch adds a lightweight environment for development purposes.
To use/install it, use standard `composer install`. 

A TYPO3 instance will be prepared for 'FIRST_INSTALL'-steps in "/.Build/".
Docroot would be "/.Build/web/".