### PR TITLE
[TASK] Prefix module identifiers with vendor name to prevent duplication

### DIFF
--- a/Classes/Modules/HooksAndSignals/Hooks.php
+++ b/Classes/Modules/HooksAndSignals/Hooks.php
@@ -49,7 +49,7 @@ class Hooks implements ModuleInterface, ContentProviderInterface, DataProviderIn
      */
     public function getIdentifier(): string
     {
-        return 'debug_hooks';
+        return 'psychomieze_debug_hooks';
     }
 
     /**

--- a/Classes/Modules/HooksAndSignals/Signals.php
+++ b/Classes/Modules/HooksAndSignals/Signals.php
@@ -66,7 +66,7 @@ class Signals implements ModuleInterface, ContentProviderInterface, DataProvider
      */
     public function getIdentifier(): string
     {
-        return 'debug_signals';
+        return 'psychomieze_debug_signals';
     }
 
     /**

--- a/Classes/Modules/Info/UserInformation.php
+++ b/Classes/Modules/Info/UserInformation.php
@@ -47,7 +47,7 @@ class UserInformation extends AbstractSubModule implements DataProviderInterface
      */
     public function getIdentifier(): string
     {
-        return 'info_userinformation';
+        return 'psychomieze_info_userinformation';
     }
 
     /**

--- a/Classes/Service/ModuleDataService.php
+++ b/Classes/Service/ModuleDataService.php
@@ -21,7 +21,6 @@ class ModuleDataService implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
-
     private $cacheManager;
 
     private const NO_SUCH_CACHE = 'Configuration error: The adminpanel is activated but the adminpanel_requestcache was not found.';
@@ -54,7 +53,6 @@ class ModuleDataService implements LoggerAwareInterface
         }
         return $moduleData instanceof ModuleData ? $moduleData : null;
     }
-
 
     /**
      * @param string $requestId

--- a/Classes/Service/SignalsService.php
+++ b/Classes/Service/SignalsService.php
@@ -5,7 +5,7 @@ namespace Psychomieze\AdminpanelExtended\Service;
 
 /*
  * This file is part of the TYPO3 Adminpanel Initiative.
- *t
+ *
  * For the full copyright and license information, please read the
  * LICENSE file that was distributed with this source code.
  */

--- a/Tests/Unit/Modules/HooksAndSignals/HooksTest.php
+++ b/Tests/Unit/Modules/HooksAndSignals/HooksTest.php
@@ -36,7 +36,7 @@ class HooksTest extends UnitTestCase
     public function getIdentifierReturnsIdentifier(): void
     {
         $identifier = $this->hooks->getIdentifier();
-        self::assertSame('debug_hooks', $identifier);
+        self::assertSame('psychomieze_debug_hooks', $identifier);
     }
 
     /**

--- a/Tests/Unit/Modules/HooksAndSignals/SignalsTest.php
+++ b/Tests/Unit/Modules/HooksAndSignals/SignalsTest.php
@@ -40,7 +40,7 @@ class SignalsTest extends UnitTestCase
     public function getIdentifierReturnsIdentifier(): void
     {
         $identifier = $this->signals->getIdentifier();
-        self::assertSame('debug_signals', $identifier);
+        self::assertSame('psychomieze_debug_signals', $identifier);
     }
 
     /**

--- a/Tests/Unit/Modules/Info/UserInformationTest.php
+++ b/Tests/Unit/Modules/Info/UserInformationTest.php
@@ -49,7 +49,7 @@ class UserInformationTest extends UnitTestCase
      */
     public function getIdentifierReturnsStaticModuleIdentifier(): void
     {
-        static::assertSame('info_userinformation', $this->subject->getIdentifier());
+        static::assertSame('psychomieze_info_userinformation', $this->subject->getIdentifier());
 
         static::assertInstanceOf(AbstractSubModule::class, $this->subject);
     }


### PR DESCRIPTION
This patch adds the vendor name to all module identifiers to prevent duplication between other third party extensions