### PR TITLE
[TASK] Add christianessl/adminpanel_int as a suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,5 +62,8 @@
     "test": [
       "@test:php:unit"
     ]
+  },
+  "suggest": {
+    "christianessl/adminpanel_int": "Extend the adminpanel by showing the actual info for each USER_INT object on the page."
   }
 }


### PR DESCRIPTION
"christianessl/adminpanel_int" provides info about INT objects.
The extension can be found here: https://github.com/IndyIndyIndy/adminpanel_int